### PR TITLE
Add the ability to add keys to the union after it has been created

### DIFF
--- a/src/quick_find.rs
+++ b/src/quick_find.rs
@@ -41,6 +41,15 @@ impl<V: Union> UnionFind<V> for QuickFindUf<V> {
     fn size(&self) -> usize { self.payload.len() }
 
     #[inline]
+    fn insert(&mut self, data: V) -> usize {
+        let key = self.payload.len();
+        self.link_root.push(key);
+        self.link_sibling.push(key);
+        self.payload.push(Some(Payload { data: data, link_last_child: key }));
+        key
+    }
+
+    #[inline]
     fn union(&mut self, key0: usize, key1: usize) -> bool {
         let k0 = self.find(key0);
         let k1 = self.find(key1);

--- a/src/quick_union.rs
+++ b/src/quick_union.rs
@@ -30,6 +30,14 @@ impl<V: Union> UnionFind<V> for QuickUnionUf<V> {
     fn size(&self) -> usize { self.payload.len() }
 
     #[inline]
+    fn insert(&mut self, data: V) -> usize {
+        let key = self.payload.len();
+        self.link_parent.push(key);
+        self.payload.push(Some(data));
+        key
+    }
+
+    #[inline]
     fn union(&mut self, key0: usize, key1: usize) -> bool {
         let k0 = self.find(key0);
         let k1 = self.find(key1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use ::{UnionFind, UnionBySize};
+use std::default::Default;
 
 pub fn union_find<T>()
     where T: UnionFind<UnionBySize>
@@ -23,6 +24,10 @@ pub fn union_find<T>()
     assert_eq!(3, uf.get(2).size());
     assert!(uf.find(0) == uf.find(1));
     assert!(uf.find(2) == uf.find(1));
+    let k100 = uf.insert(UnionBySize::default());
+    assert_eq!(k100, 100);
+    uf.union(k100, 0);
+    assert_eq!(4, uf.get(100).size());
 }
 
 mod quick_union {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -26,6 +26,10 @@ pub trait UnionFind<V: Union>: FromIterator<V> + Sized {
     /// Returns the size of `self`.
     fn size(&self) -> usize;
 
+    ///Inserts a new key into the union.
+    ///Returns the key of the inserted set
+    fn insert(&mut self, data: V) -> usize;
+
     /// Join two sets that contains given keys (Union operation).
     ///
     /// Returns `true` if these keys are belonged to different sets.


### PR DESCRIPTION
For typechecking in https://github.com/Marwes/embed_lang I do not know how many variables I need beforehand so I added the ability to add new keys after the Union was created. Figure it might be useful upstream as well. If you have any ideas for how to make this better I am happy to update this PR.
