### PR TITLE
fix: UnionByRankSize Default constructor has inverted arguments

### DIFF
--- a/src/union.rs
+++ b/src/union.rs
@@ -169,7 +169,7 @@ impl Union for UnionByRankSize {
 impl Default for UnionByRankSize {
     #[inline]
     fn default() -> UnionByRankSize {
-        UnionByRankSize(1, 0)
+        UnionByRankSize(0, 1)
     }
 }
 


### PR DESCRIPTION
Fixes #12 