### PR TITLE
docs: fix README MSRV version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/crates/l/union-find.svg)](#license)
 [![crates.io](https://img.shields.io/crates/v/union-find.svg)](https://crates.io/crates/union-find)
 [![docs.rs](https://img.shields.io/docsrs/union-find/latest)](https://docs.rs/union-find/latest/)
-[![rust 1.80.0+ badge](https://img.shields.io/badge/rust-1.80.0+-93450a.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![rust 1.86.0+ badge](https://img.shields.io/badge/rust-1.86.0+-93450a.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![Rust CI](https://github.com/gifnksm/union-find-rs/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/gifnksm/union-find-rs/actions/workflows/rust-ci.yml)
 [![codecov](https://codecov.io/gh/gifnksm/union-find-rs/branch/master/graph/badge.svg?token=fKfEmEaMjc)](https://codecov.io/gh/gifnksm/union-find-rs)
 
@@ -23,11 +23,13 @@ union-find = "0.4.4"
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.80.0**.
+The minimum supported Rust version is **Rust 1.86.0**.
 At least the last 3 versions of stable Rust are supported at any given time.
 
-While a crate is pre-release status (0.x.x) it may have its MSRV bumped in a patch release.
-Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.
+While a crate is pre-release status (0.x.x) it may have its MSRV
+bumped in a patch release.
+Once a crate has reached 1.x, any MSRV bump will be accompanied
+with a new minor version.
 
 ## License
 


### PR DESCRIPTION
## Summary

- update the README Rust version badge from `1.80.0` to `1.86.0`
- update the README MSRV text to match `Cargo.toml`
- wrap long lines to satisfy markdownlint

This keeps the README consistent with the crate manifest and CI configuration.
